### PR TITLE
[vim] Made λ to be a valid function in `func?`

### DIFF
--- a/fnl/hibiscus/vim.fnl
+++ b/fnl/hibiscus/vim.fnl
@@ -9,7 +9,7 @@
 (lambda func? [x]
   "checks if 'x' is function definition."
   (let [ref (?. x 1 1)]
-    (or= ref :fn :hashfn :lambda :partial)))
+    (or= ref :λ :fn :hashfn :lambda :partial)))
 
 (lambda quote? [x]
   "checks if 'x' is quoted value."


### PR DESCRIPTION
Fixes an issue with some macros not recognizing λ as a function declaration form.